### PR TITLE
Wrap nsf/termbox 1.1.2

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,11 @@
+project('termbox', 'c', version: '1.1.2')
+
+src = ['src/utf8.c', 'src/termbox.c']
+c_args = ['-D_XOPEN_SOURCE']
+lib = library('termbox', src, c_args: c_args)
+
+configure_file(copy: true, input: 'src/termbox.h', output: 'termbox.h')
+inc = include_directories('.')
+
+termbox_dep = declare_dependency(link_with: lib, include_directories: inc)
+meson.override_dependency('termbox', termbox_dep)

--- a/upstream.wrap
+++ b/upstream.wrap
@@ -1,0 +1,8 @@
+[wrap-file]
+directory = termbox-1.1.2
+source_url = https://github.com/nsf/termbox/archive/v1.1.2.zip
+source_filename = v1.1.2.zip
+source_hash = 428dc9559243f4ddf2ca52015b01c8334c1a1eb55f974b68468c309d24dc0dfd
+
+[provide]
+termbox = termbox_dep


### PR DESCRIPTION
Upstream tag was made on March 2018
Developed with meson 0.56.0